### PR TITLE
feat(map): Set OSM and Zoom 3 as default options on Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.svelte-kit

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",
-				"@sveltejs/adapter-netlify": "^4.3.1",
 				"@sveltejs/adapter-static": "^3.0.4",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -697,12 +696,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-			"dev": true
-		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -1026,20 +1019,6 @@
 			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
-			}
-		},
-		"node_modules/@sveltejs/adapter-netlify": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-4.3.1.tgz",
-			"integrity": "sha512-KG/We5SbNygKSSU2zagWqLrV7RGHlmcnOPWn/9W9RYjNaMwgsvtw+4h50lP12+Dj9dZ2xDZcBl/X+R9kgiuL5g==",
-			"dev": true,
-			"dependencies": {
-				"@iarna/toml": "^2.2.5",
-				"esbuild": "^0.21.5",
-				"set-cookie-parser": "^2.6.0"
-			},
-			"peerDependencies": {
-				"@sveltejs/kit": "^2.4.0"
 			}
 		},
 		"node_modules/@sveltejs/adapter-static": {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -362,7 +362,7 @@ export function initializeMap(target: HTMLElement) {
   map = new OLMap({
     target: target,
     layers: [
-      mapTileLayers.osm, // Default base layer
+      mapTileLayers.blank, // Default base layer
     ],
     view: new View({
       center: fromLonLat([0, 0]),

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,36 +1,29 @@
+import { fromGeo } from "@bte-germany/terraconvert";
+import { default as Collection } from "ol/Collection";
+import { default as Feature } from "ol/Feature";
 import OLMap from "ol/Map";
 import View from "ol/View";
+import { defaults as defaultControls } from "ol/control";
+import { click } from "ol/events/condition";
+import type { Extent } from "ol/extent";
+import { GeoJSON } from "ol/format"; // Import GeoJSON format for handling GeoJSON data
+import { Polygon } from "ol/geom";
+import { defaults as defaultInteractions, DragRotate } from "ol/interaction";
+import DoubleClickZoom from "ol/interaction/DoubleClickZoom";
+import Draw, { createBox } from "ol/interaction/Draw";
+import Modify from "ol/interaction/Modify";
+import Select from "ol/interaction/Select";
+import Translate from "ol/interaction/Translate";
 import VectorLayer from "ol/layer/Vector";
-import VectorSource from "ol/source/Vector";
-import Feature from "ol/Feature";
-import { Style, Fill, Stroke } from "ol/style";
 import {
   fromLonLat,
   toLonLat,
-  transform,
-  get as getProjection,
-  type ProjectionLike,
-  transformExtent,
+  transform
 } from "ol/proj";
-import Draw, { createBox } from "ol/interaction/Draw";
-import Select from "ol/interaction/Select";
-import Translate from "ol/interaction/Translate";
-import Modify from "ol/interaction/Modify";
-import { click } from "ol/events/condition";
-import Collection from "ol/Collection";
-import { defaults as defaultControls } from "ol/control";
-import DoubleClickZoom from "ol/interaction/DoubleClickZoom";
-import { defaults as defaultInteractions, DragRotate } from "ol/interaction";
-import { MapTileLayer, mapTileLayers } from "./mapTileUtils";
-import { GeoJSON } from "ol/format"; // Import GeoJSON format for handling GeoJSON data
+import VectorSource from "ol/source/Vector";
+import { Fill, Stroke, Style } from "ol/style";
 import { writable } from "svelte/store";
-import { fromGeo } from "@bte-germany/terraconvert";
-import { Polygon } from "ol/geom";
-import type { Extent } from "ol/extent";
-import GeoImage from "ol-ext/layer/GeoImage";
-import GeoImageSource from "ol-ext/source/GeoImage";
-import ImageLayer from "ol/layer/Image";
-import ImageStatic from "ol/source/ImageStatic";
+import { MapTileLayer, mapTileLayers } from "./mapTileUtils";
 
 // Create a Svelte store to keep track of the selected feature type
 export const selectedFeature = writable<Feature | null>(null);
@@ -369,11 +362,11 @@ export function initializeMap(target: HTMLElement) {
   map = new OLMap({
     target: target,
     layers: [
-      mapTileLayers.blank, // Default base layer
+      mapTileLayers.osm, // Default base layer
     ],
     view: new View({
       center: fromLonLat([0, 0]),
-      zoom: 17,
+      zoom: 3,
     }),
     controls: defaultControls({
       zoom: false,


### PR DESCRIPTION
Ive wondered why the Map doesnt display a Map by default and instead shows the Blank grid. Since i couldnt figure out a reason, i just changed it. Additionally i also set the zoom lower, so you can directly see the entire world and dont need to zoom out for 10 seconds.

If there are any reasons why the blank map is shown by default, just close this PR.

### Summary

* Modified the `initializeMap` function to change the default base layer from `mapTileLayers.blank` to `mapTileLayers.osm`, providing a more useful default view for users. Additionally, the default zoom level was adjusted from 17 to 3, offering a broader initial view of the map.
* Include a .gitignore file to leave node_modules and .svelte-kit files on local file systems.